### PR TITLE
feat: FlutterErrorやFlutter外部のエラーをCrashlyticsに送信する設定を追加

### DIFF
--- a/packages/analysis_logger/lib/src/analysis_logger.dart
+++ b/packages/analysis_logger/lib/src/analysis_logger.dart
@@ -5,11 +5,8 @@ import 'package:authenticator/authenticator.dart' show SigningMethod;
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/foundation.dart';
-import 'package:riverpod/riverpod.dart';
 
 import 'analysis_event.dart';
-
-final analysisLoggerProvider = Provider((ref) => AnalysisLogger());
 
 /// 解析に必要なログを送信する役割を持つ。
 ///

--- a/packages/analysis_logger/lib/src/analysis_logger.dart
+++ b/packages/analysis_logger/lib/src/analysis_logger.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
+import 'dart:isolate';
 
 import 'package:authenticator/authenticator.dart' show SigningMethod;
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:flutter/foundation.dart';
 import 'package:riverpod/riverpod.dart';
 
 import 'analysis_event.dart';
@@ -105,5 +107,49 @@ class AnalysisLogger {
       parameters: event.parameters,
       callOptions: global == null ? null : AnalyticsCallOptions(global: global),
     );
+  }
+
+  /// Flutterフレームワークがキャッチしたエラーを記録するコールバック。
+  ///
+  /// 使用例：
+  /// ```dart
+  /// FlutterError.onError = analysisLogger.onFlutterError;
+  /// ```
+  Future<void> onFlutterError(
+    FlutterErrorDetails flutterErrorDetails, {
+    bool fatal = false,
+  }) async {
+    FlutterError.presentError(flutterErrorDetails);
+    await _crashlytics.recordFlutterError(flutterErrorDetails, fatal: fatal);
+  }
+
+  /// Flutterフレームワークでキャッチできない非同期エラーを記録するコールバック。
+  ///
+  /// 使用例：
+  /// ```dart
+  /// PlatformDispatcher.instance.onError = analysisLogger.onPlatformError;
+  /// ```
+  bool onPlatformError(Object error, StackTrace stack) {
+    unawaited(_crashlytics.recordError(error, stack, fatal: true));
+    return true;
+  }
+
+  /// Flutter外部のエラーを記録するために[Isolate.current]に登録するリスナー。
+  ///
+  /// 使用例：
+  /// ```dart
+  /// Isolate.current.addErrorListener(
+  ///   analysisLogger.isolateErrorListener()
+  /// );
+  /// ```
+  SendPort isolateErrorListener() {
+    return RawReceivePort((List<dynamic> pair) async {
+      final errorAndStacktrace = pair;
+      await _crashlytics.recordError(
+        errorAndStacktrace.first,
+        errorAndStacktrace.last as StackTrace,
+        fatal: true,
+      );
+    }).sendPort;
   }
 }

--- a/packages/analysis_logger/pubspec.yaml
+++ b/packages/analysis_logger/pubspec.yaml
@@ -13,13 +13,10 @@ dependencies:
   firebase_crashlytics: ^3.3.1
   flutter:
     sdk: flutter
-  riverpod: ^2.3.0
-  riverpod_annotation: ^2.0.0
 
 dev_dependencies:
   altive_lints: ^1.7.0
   flutter_test:
     sdk: flutter
-  riverpod_generator: ^2.0.0
 
 flutter:

--- a/packages/flutter_app/lib/main.dart
+++ b/packages/flutter_app/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'environment/environment.dart';
 import 'features/user_device/user_device.dart';
 import 'flutter_app.dart';
+import 'package_adaptor/analysis_logger/analysis_logger_provider.dart';
 import 'util/providers/providers.dart';
 
 Future<void> main() async {

--- a/packages/flutter_app/lib/main.dart
+++ b/packages/flutter_app/lib/main.dart
@@ -27,13 +27,13 @@ Future<void> main() async {
     retrieveUserDevice(),
   ).wait;
 
-  final analyticsReporter = AnalysisLogger();
+  final analysisLogger = AnalysisLogger();
   // Flutterフレームワークがキャッチしたエラーを記録する。
-  FlutterError.onError = analyticsReporter.onFlutterError;
+  FlutterError.onError = analysisLogger.onFlutterError;
   // Flutterフレームワークでキャッチできない非同期エラーを記録する。
-  PlatformDispatcher.instance.onError = analyticsReporter.onPlatformError;
+  PlatformDispatcher.instance.onError = analysisLogger.onPlatformError;
   // Flutter外部のエラーを記録する。
-  Isolate.current.addErrorListener(analyticsReporter.isolateErrorListener());
+  Isolate.current.addErrorListener(analysisLogger.isolateErrorListener());
 
   runApp(
     ProviderScope(
@@ -42,7 +42,7 @@ Future<void> main() async {
         sharedPreferencesProvider.overrideWithValue(sharedPreferences),
         packageInfoProvider.overrideWithValue(packageInfo),
         userDeviceProvider.overrideWithValue(userDevice),
-        analysisLoggerProvider.overrideWithValue(analyticsReporter),
+        analysisLoggerProvider.overrideWithValue(analysisLogger),
       ],
       child: const FlutterApp(),
     ),

--- a/packages/flutter_app/lib/package_adaptor/analysis_logger/analysis_logger_provider.dart
+++ b/packages/flutter_app/lib/package_adaptor/analysis_logger/analysis_logger_provider.dart
@@ -1,0 +1,10 @@
+import 'package:analysis_logger/analysis_logger.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'analysis_logger_provider.g.dart';
+
+/// `analysis_logger` バッケージの `AnalysisLogger` クラスインスタンスを提供する。
+@Riverpod(keepAlive: true)
+AnalysisLogger analysisLogger(AnalysisLoggerRef ref) {
+  throw UnimplementedError();
+}

--- a/packages/flutter_app/lib/package_adaptor/analysis_logger/analysis_logger_provider.dart
+++ b/packages/flutter_app/lib/package_adaptor/analysis_logger/analysis_logger_provider.dart
@@ -3,7 +3,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'analysis_logger_provider.g.dart';
 
-/// `analysis_logger` バッケージの `AnalysisLogger` クラスインスタンスを提供する。
+/// `analysis_logger` パッケージの `AnalysisLogger` クラスインスタンスを提供する。
 @Riverpod(keepAlive: true)
 AnalysisLogger analysisLogger(AnalysisLoggerRef ref) {
   throw UnimplementedError();

--- a/packages/flutter_app/lib/package_adaptor/analysis_logger/analysis_logger_provider.g.dart
+++ b/packages/flutter_app/lib/package_adaptor/analysis_logger/analysis_logger_provider.g.dart
@@ -1,0 +1,28 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint, implicit_dynamic_parameter, implicit_dynamic_type, implicit_dynamic_method, strict_raw_type
+
+part of 'analysis_logger_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$analysisLoggerHash() => r'8fc3dc469dadbb93a45c4fae625c2af7ccc51ecd';
+
+/// `analysis_logger` バッケージの `AnalysisLogger` クラスインスタンスを提供する。
+///
+/// Copied from [analysisLogger].
+@ProviderFor(analysisLogger)
+final analysisLoggerProvider = Provider<AnalysisLogger>.internal(
+  analysisLogger,
+  name: r'analysisLoggerProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$analysisLoggerHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef AnalysisLoggerRef = ProviderRef<AnalysisLogger>;
+// ignore_for_file: unnecessary_raw_strings, subtype_of_sealed_class, invalid_use_of_internal_member, do_not_use_environment, prefer_const_constructors, public_member_api_docs, avoid_private_typedef_functions

--- a/packages/flutter_app/lib/package_adaptor/analysis_logger/analysis_logger_provider.g.dart
+++ b/packages/flutter_app/lib/package_adaptor/analysis_logger/analysis_logger_provider.g.dart
@@ -10,7 +10,7 @@ part of 'analysis_logger_provider.dart';
 
 String _$analysisLoggerHash() => r'8fc3dc469dadbb93a45c4fae625c2af7ccc51ecd';
 
-/// `analysis_logger` バッケージの `AnalysisLogger` クラスインスタンスを提供する。
+/// `analysis_logger` パッケージの `AnalysisLogger` クラスインスタンスを提供する。
 ///
 /// Copied from [analysisLogger].
 @ProviderFor(analysisLogger)


### PR DESCRIPTION
## 🔗 Issue リンク

closes #192 

## 🙌 やったこと

<!-- このプルリクで何をしたのか？ -->

- FlutterErrorやFlutter外部のエラーをCrashlyticsに送信する設定を追加

## ✍️ やらないこと

<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK） -->

- なし

## ✅ 動作確認

<!-- ビルド・起動確認＋必要な動作確認があれば追記 -->

- [ ] Android
- [x] iOS
- [ ] macOS
- [ ] Web

## スクリーンショット

<!-- UIに変更箇所がある場合はBefore, Afterのキャプチャ画像、もしくは動画を添付する -->

## その他

<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
