### PR TITLE
fix: --dart-define-from-fileで指定する設定ファイルを.envに変更

### DIFF
--- a/.github/actions/upload_android_app/action.yml
+++ b/.github/actions/upload_android_app/action.yml
@@ -62,7 +62,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
 
     - name: Building Android AppBundle
-      run: flutter build appbundle --dart-define-from-file=dart_defines/${{ inputs.flavor }}.json --build-number ${{ inputs.build-number }}
+      run: flutter build appbundle --dart-define-from-file=dart_defines/${{ inputs.flavor }}.env --build-number ${{ inputs.build-number }}
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,7 @@ coverage/
 .env*
 *.env
 !.env.sample
+!/packages/flutter_app/dart_defines/*.env
 *env.g.dart
 
 # Exceptions to above rules.

--- a/.gitignore
+++ b/.gitignore
@@ -144,14 +144,6 @@ coverage/
 # Bundler related
 **/vendor/bundle
 
-# ENV
-.envrc
-.env*
-*.env
-!.env.sample
-!/packages/flutter_app/dart_defines/*.env
-*env.g.dart
-
 # Exceptions to above rules.
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
 !/dev/ci/**/Gemfile.lock

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
             "type": "dart",
             "flutterMode": "debug",
             "args": [
-                "--dart-define-from-file=dart_defines/dev.json"
+                "--dart-define-from-file=dart_defines/dev.env"
             ]
         },
         {
@@ -23,7 +23,7 @@
             "type": "dart",
             "flutterMode": "debug",
             "args": [
-                "--dart-define-from-file=dart_defines/stg.json"
+                "--dart-define-from-file=dart_defines/stg.env"
             ]
         },
         {
@@ -34,7 +34,7 @@
             "type": "dart",
             "flutterMode": "debug",
             "args": [
-                "--dart-define-from-file=dart_defines/prod.json"
+                "--dart-define-from-file=dart_defines/prod.env"
             ]
         }
     ]

--- a/README-ja.md
+++ b/README-ja.md
@@ -121,7 +121,7 @@ make
 1. Create a project in Firebase.
   1. Create an Android app, download `google-services.json`, and place it in `android/app/src/{dev or stg or prod}`.
   1. Create an iOS app, download `GoogleService-Info.plist`, and place it in `ios/{dev or stg or prod}`.
-  1. Modify `googleReversedClientId` in `dart_defines/{dev, stg, prod}.json` to match the contents of each `GoogleService-Info.plist`.
+  1. Modify `googleReversedClientId` in `dart_defines/{dev, stg, prod}.env` to match the contents of each `GoogleService-Info.plist`.
   1. Create a Web app and modify the parameters in `firebaseConfig` in `web/index.html` according to the Firebase SDK additions.
     - apiKey, authDomain, databaseURL, projectId, storageBucket, messagingSenderId, appId, measurementId
     

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The `make` command will install the required Dart packages, such as FVM and Melo
 1. Create a project in Firebase.
   1. Create an Android app, download `google-services.json`, and place it in `android/app/src/{dev or stg or prod}`.
   1. Create an iOS app, download `GoogleService-Info.plist`, and place it in `ios/{dev or stg or prod}`.
-  1. Modify `googleReversedClientId` in `dart_defines/{dev, stg, prod}.json` to match the contents of each `GoogleService-Info.plist`.
+  1. Modify `googleReversedClientId` in `dart_defines/{dev, stg, prod}.env` to match the contents of each `GoogleService-Info.plist`.
   1. Create a Web app and modify the parameters in `firebaseConfig` in `web/index.html` according to the Firebase SDK additions.
     - apiKey, authDomain, databaseURL, projectId, storageBucket, messagingSenderId, appId, measurementId
     

--- a/melos.yaml
+++ b/melos.yaml
@@ -155,7 +155,7 @@ scripts:
   build:android:prod:
     run: |
       melos exec -c 1 -- \
-        flutter build appbundle --dart-define-from-file=dart_defines/prod.json
+        flutter build appbundle --dart-define-from-file=dart_defines/prod.env
     description: Build the AppBundle for the production app.
     packageFilters:
       flutter: true
@@ -164,7 +164,7 @@ scripts:
   upload:ios:prod:
     run: |
       melos exec -c 1 -- \
-        flutter build ipa --dart-define-from-file=dart_defines/prod.json --export-options-plist="ios/prod/ExportOptions.plist"
+        flutter build ipa --dart-define-from-file=dart_defines/prod.env --export-options-plist="ios/prod/ExportOptions.plist"
     description: Upload the IPA for the production app.
     packageFilters:
       flutter: true

--- a/packages/flutter_app/.gitignore
+++ b/packages/flutter_app/.gitignore
@@ -145,3 +145,11 @@ ios/Runner/GoogleService-Info.plist
 macos/firebase_app_id_file.json
 macos/Runner/GoogleService-Info.plist
 android/app/google-services.json
+
+# Environment
+.envrc
+.env*
+*.env
+!.env.sample
+*env.g.dart
+!dart_defines/*.env

--- a/packages/flutter_app/dart_defines/dev.env
+++ b/packages/flutter_app/dart_defines/dev.env
@@ -1,0 +1,5 @@
+flavor="dev"
+appName="FAT dev"
+appIdSuffix=".dev"
+googleReversedClientId="com.googleusercontent.apps.1068511233454-jqkcgldo7cro8bsap1j574959nmgfjqe",
+providerLogPrint="dispose,error"

--- a/packages/flutter_app/dart_defines/dev.json
+++ b/packages/flutter_app/dart_defines/dev.json
@@ -1,7 +1,0 @@
-{
-    "flavor": "dev",
-    "appName": "FAT dev",
-    "appIdSuffix": ".dev",
-    "googleReversedClientId": "com.googleusercontent.apps.1068511233454-jqkcgldo7cro8bsap1j574959nmgfjqe",
-    "providerLogPrint": "dispose,error"
-}

--- a/packages/flutter_app/dart_defines/prod.env
+++ b/packages/flutter_app/dart_defines/prod.env
@@ -1,0 +1,5 @@
+flavor="prod"
+appName="FAT"
+appIdSuffix=""
+googleReversedClientId="com.googleusercontent.apps.1007652573613-2ggi30iortpdb6gilpfli5ouk6ruckhg"
+providerLogPrint=""

--- a/packages/flutter_app/dart_defines/prod.json
+++ b/packages/flutter_app/dart_defines/prod.json
@@ -1,7 +1,0 @@
-{
-    "flavor": "prod",
-    "appName": "FAT",
-    "appIdSuffix": "",
-    "googleReversedClientId": "com.googleusercontent.apps.1007652573613-2ggi30iortpdb6gilpfli5ouk6ruckhg",
-    "providerLogPrint": ""
-}

--- a/packages/flutter_app/dart_defines/stg.env
+++ b/packages/flutter_app/dart_defines/stg.env
@@ -1,0 +1,5 @@
+flavor="stg"
+appName="FAT stg"
+appIdSuffix=".stg"
+googleReversedClientId="com.googleusercontent.apps.502626918852-9h1ius8m1asenmeu9a770orn23jsmbh1"
+providerLogPrint="dispose,error"

--- a/packages/flutter_app/dart_defines/stg.json
+++ b/packages/flutter_app/dart_defines/stg.json
@@ -1,7 +1,0 @@
-{
-    "flavor": "stg",
-    "appName": "FAT stg",
-    "appIdSuffix": ".stg",
-    "googleReversedClientId": "com.googleusercontent.apps.502626918852-9h1ius8m1asenmeu9a770orn23jsmbh1",
-    "providerLogPrint": "dispose,error"
-}


### PR DESCRIPTION
## 🔗 Issue リンク

closes #281

## 🙌 やったこと

<!-- このプルリクで何をしたのか？ -->
- {flavor}.json から {flavor}.env にファイル名変更
- 以下のファイル内で{flavor}.jsonとなっている箇所を{flavor}.envに変更
  - launch.json
  - melos.yaml
  - README-ja.md
  - README.md
- .gitingoreに"*.env"を無視するように記載されているが、{flavor}.envは対象外とすることを追記

## ✍️ やらないこと

<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK） -->
なし

## ✅ 動作確認

<!-- ビルド・起動確認＋必要な動作確認があれば追記 -->

- [ ] Android
- [ ] iOS
- [ ] macOS
- [ ] Web

## スクリーンショット

<!-- UIに変更箇所がある場合はBefore, Afterのキャプチャ画像、もしくは動画を添付する -->

## その他

<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
