### PR TITLE
fix: Android source directories merging

### DIFF
--- a/packages/flutter_app/android/app/build.gradle
+++ b/packages/flutter_app/android/app/build.gradle
@@ -44,6 +44,11 @@ task selectGoogleServicesJson(type: Copy) {
     into './'
 }
 
+task copySources(type: Copy) {
+    from "src/${dartDefines.flavor}/res"
+    into 'src/main/res'
+}
+
 tasks.whenTaskAdded { task ->
     if (task.name == 'processDebugGoogleServices' || task.name == 'processReleaseGoogleServices') {
         task.dependsOn selectGoogleServicesJson
@@ -61,7 +66,7 @@ android {
     sourceSets {
         main {
             java.srcDirs += 'src/main/kotlin'
-            res.srcDirs = ['src/main/res', "src/${dartDefines.flavor}/res"]
+            res.srcDirs = ['src/main/res']
         }
     }
 


### PR DESCRIPTION
## 🙌 What's Done
<!-- What has been done in this Pull Request? -->

Running `flutter create` will generate a launcher icon image in 'src/main/res'.
With the pre-modified method, it tries to merge the contents of 'src/$flavour/res' into 'src/main/res', but this results in an error because of duplicate files.
So we changed to copying using `task copySources`!

## ✍️ What's Not Done
<!-- What is not done in this Pull Request? If none, write "None". -->
- 

## 🤼 Desired Review Method
<!-- Select the review method you expect reviewers to use. -->

- [ ] Correction Commit
- [ ] Pair programming

> [!NOTE]
> It is possible that a reviewer's will may cause a method to be implemented that is not selected.

## 📝 Additional Notes
<!-- Additional information for reviewers, such as concerns or notes for the implementation. -->

## Pre-launch Checklist
- [x] I have reviewed my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I updated/added relevant documentation (doc comments with ///).