### PR TITLE
fix: Fix network image exception for macOS

### DIFF
--- a/packages/flutter_app/macos/Runner/DebugProfile.entitlements
+++ b/packages/flutter_app/macos/Runner/DebugProfile.entitlements
@@ -10,5 +10,7 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>

--- a/packages/flutter_app/macos/Runner/Release.entitlements
+++ b/packages/flutter_app/macos/Runner/Release.entitlements
@@ -6,5 +6,7 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## 🙌 What's Done
<!-- What has been done in this Pull Request? -->
- Fix network image exception for macOS

## ✍️ What's Not Done
<!-- What is not done in this Pull Request? If none, write "None". -->
- 

## 🖼️ Image Differences
<!-- Attach Before and After capture images or videos if there are UI changes. -->

### After
<img src="https://github.com/user-attachments/assets/05d6db63-fb8b-43cd-878f-efff9ee9d068" width=350px />

## 🤼 Desired Review Method
<!-- Select the review method you expect reviewers to use. -->

- [ ] Correction Commit
- [ ] Pair programming

> [!NOTE]
> It is possible that a reviewer's will may cause a method to be implemented that is not selected.

## 📝 Additional Notes
<!-- Additional information for reviewers, such as concerns or notes for the implementation. -->

- https://stackoverflow.com/q/65458903

## Pre-launch Checklist
- [x] I have reviewed my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I updated/added relevant documentation (doc comments with ///).