### PR TITLE
fix: Organize build.yaml with GoRouter v15

### DIFF
--- a/packages/convenient_widgets/build.yaml
+++ b/packages/convenient_widgets/build.yaml
@@ -1,0 +1,12 @@
+targets:
+  $default:
+    sources:
+      include:
+        - $package$ # Package metadata.
+        - pubspec.yaml # FlutterGen configuration.
+        - lib/** # Dart source files.
+        - assets/** # Asset files for FlutterGen.
+    builders:
+      flutter_gen_runner:
+        options:
+          output: lib/gen/

--- a/packages/convenient_widgets/pubspec.yaml
+++ b/packages/convenient_widgets/pubspec.yaml
@@ -26,8 +26,6 @@ flutter_gen:
   integrations:
     image: true
     flutter_svg: true
-    rive: false
-    lottie: false
 
 flutter:
   assets:

--- a/packages/flutter_app/build.yaml
+++ b/packages/flutter_app/build.yaml
@@ -1,6 +1,15 @@
 targets:
   $default:
+    sources:
+      include:
+        - $package$ # Package metadata.
+        - pubspec.yaml # FlutterGen and other builders configuration.
+        - lib/** # Dart source files.
+        - assets/** # Asset files for FlutterGen.
     builders:
+      flutter_gen_runner:
+        options:
+          output: lib/gen/
       source_gen|combining_builder:
         options:
           ignore_for_file:

--- a/packages/flutter_app/pubspec.yaml
+++ b/packages/flutter_app/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   flutter_svg: ^2.0.16
   freezed_annotation: ^3.0.0
   gap: ^3.0.1
-  go_router: ^14.8.1
+  go_router: ^15.1.2
   google_sign_in: ^6.3.0
   hooks_riverpod: ^2.6.1
   image_picker: ^1.1.2
@@ -66,12 +66,17 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   freezed: ^3.0.6
-  go_router_builder: ^2.8.2
+  go_router_builder: ^2.9.0
   json_serializable: ^6.9.5
   mockito: ^5.4.6
   riverpod_generator: ^2.6.3
   riverpod_lint: ^2.6.1
   slang_build_runner: ^4.3.0
+
+flutter_gen:
+  integrations:
+    image: true
+    flutter_svg: true
 
 flutter:
   uses-material-design: true

--- a/packages/pub_dev_api_client/build.yaml
+++ b/packages/pub_dev_api_client/build.yaml
@@ -1,0 +1,24 @@
+targets:
+  $default:
+    sources:
+      include:
+        - $package$ # Package metadata.
+        - pubspec.yaml # Package configuration.
+        - lib/** # Dart source files.
+    builders:
+      freezed:
+        generate_for:
+          include:
+            - lib/**/models/*.dart
+      json_serializable:
+        generate_for:
+          include:
+            - lib/**/models/*.dart
+        options:
+          checked: true
+          explicit_to_json: true
+          field_rename: snake
+      retrofit_generator:
+        generate_for:
+          include:
+            - lib/**/*_client.dart 

--- a/packages/pub_dev_api_client/lib/src/models/get_package_details_response_body.g.dart
+++ b/packages/pub_dev_api_client/lib/src/models/get_package_details_response_body.g.dart
@@ -8,11 +8,20 @@ part of 'get_package_details_response_body.dart';
 
 _GetPackageDetailsResponseBody _$GetPackageDetailsResponseBodyFromJson(
   Map<String, dynamic> json,
-) => _GetPackageDetailsResponseBody(
-  name: json['name'] as String,
-  latest: LatestPackageRelease.fromJson(json['latest'] as Map<String, dynamic>),
-);
+) => $checkedCreate('_GetPackageDetailsResponseBody', json, ($checkedConvert) {
+  final val = _GetPackageDetailsResponseBody(
+    name: $checkedConvert('name', (v) => v as String),
+    latest: $checkedConvert(
+      'latest',
+      (v) => LatestPackageRelease.fromJson(v as Map<String, dynamic>),
+    ),
+  );
+  return val;
+});
 
 Map<String, dynamic> _$GetPackageDetailsResponseBodyToJson(
   _GetPackageDetailsResponseBody instance,
-) => <String, dynamic>{'name': instance.name, 'latest': instance.latest};
+) => <String, dynamic>{
+  'name': instance.name,
+  'latest': instance.latest.toJson(),
+};

--- a/packages/pub_dev_api_client/lib/src/models/get_searched_packages_response_body.g.dart
+++ b/packages/pub_dev_api_client/lib/src/models/get_searched_packages_response_body.g.dart
@@ -8,16 +8,27 @@ part of 'get_searched_packages_response_body.dart';
 
 _GetSearchedPackagesResponseBody _$GetSearchedPackagesResponseBodyFromJson(
   Map<String, dynamic> json,
-) => _GetSearchedPackagesResponseBody(
-  packages: (json['packages'] as List<dynamic>)
-      .map((e) => PackageName.fromJson(e as Map<String, dynamic>))
-      .toList(),
-  nextPageUrl: json['next'] as String?,
+) => $checkedCreate(
+  '_GetSearchedPackagesResponseBody',
+  json,
+  ($checkedConvert) {
+    final val = _GetSearchedPackagesResponseBody(
+      packages: $checkedConvert(
+        'packages',
+        (v) => (v as List<dynamic>)
+            .map((e) => PackageName.fromJson(e as Map<String, dynamic>))
+            .toList(),
+      ),
+      nextPageUrl: $checkedConvert('next', (v) => v as String?),
+    );
+    return val;
+  },
+  fieldKeyMap: const {'nextPageUrl': 'next'},
 );
 
 Map<String, dynamic> _$GetSearchedPackagesResponseBodyToJson(
   _GetSearchedPackagesResponseBody instance,
 ) => <String, dynamic>{
-  'packages': instance.packages,
+  'packages': instance.packages.map((e) => e.toJson()).toList(),
   'next': instance.nextPageUrl,
 };

--- a/packages/pub_dev_api_client/lib/src/models/latest_package_release.g.dart
+++ b/packages/pub_dev_api_client/lib/src/models/latest_package_release.g.dart
@@ -8,10 +8,16 @@ part of 'latest_package_release.dart';
 
 _LatestPackageRelease _$LatestPackageReleaseFromJson(
   Map<String, dynamic> json,
-) => _LatestPackageRelease(
-  pubspec: PackagePubspec.fromJson(json['pubspec'] as Map<String, dynamic>),
-);
+) => $checkedCreate('_LatestPackageRelease', json, ($checkedConvert) {
+  final val = _LatestPackageRelease(
+    pubspec: $checkedConvert(
+      'pubspec',
+      (v) => PackagePubspec.fromJson(v as Map<String, dynamic>),
+    ),
+  );
+  return val;
+});
 
 Map<String, dynamic> _$LatestPackageReleaseToJson(
   _LatestPackageRelease instance,
-) => <String, dynamic>{'pubspec': instance.pubspec};
+) => <String, dynamic>{'pubspec': instance.pubspec.toJson()};

--- a/packages/pub_dev_api_client/lib/src/models/package_name.g.dart
+++ b/packages/pub_dev_api_client/lib/src/models/package_name.g.dart
@@ -7,7 +7,12 @@ part of 'package_name.dart';
 // **************************************************************************
 
 _PackageName _$PackageNameFromJson(Map<String, dynamic> json) =>
-    _PackageName(name: json['package'] as String);
+    $checkedCreate('_PackageName', json, ($checkedConvert) {
+      final val = _PackageName(
+        name: $checkedConvert('package', (v) => v as String),
+      );
+      return val;
+    }, fieldKeyMap: const {'name': 'package'});
 
 Map<String, dynamic> _$PackageNameToJson(_PackageName instance) =>
     <String, dynamic>{'package': instance.name};

--- a/packages/pub_dev_api_client/lib/src/models/package_pubspec.g.dart
+++ b/packages/pub_dev_api_client/lib/src/models/package_pubspec.g.dart
@@ -7,11 +7,14 @@ part of 'package_pubspec.dart';
 // **************************************************************************
 
 _PackagePubspec _$PackagePubspecFromJson(Map<String, dynamic> json) =>
-    _PackagePubspec(
-      name: json['name'] as String,
-      version: json['version'] as String,
-      description: json['description'] as String,
-    );
+    $checkedCreate('_PackagePubspec', json, ($checkedConvert) {
+      final val = _PackagePubspec(
+        name: $checkedConvert('name', (v) => v as String),
+        version: $checkedConvert('version', (v) => v as String),
+        description: $checkedConvert('description', (v) => v as String),
+      );
+      return val;
+    });
 
 Map<String, dynamic> _$PackagePubspecToJson(_PackagePubspec instance) =>
     <String, dynamic>{

--- a/packages/pub_dev_api_client/pubspec.yaml
+++ b/packages/pub_dev_api_client/pubspec.yaml
@@ -10,6 +10,7 @@ resolution: workspace
 dependencies:
   dio: ^5.8.0+1
   freezed_annotation: ^3.0.0
+  json_annotation: ^4.9.0
   mock_web_server: ^5.0.0-nullsafety.1
   mockito: ^5.4.6
   retrofit: ^4.4.1

--- a/packages/widget_catalog/build.yaml
+++ b/packages/widget_catalog/build.yaml
@@ -1,5 +1,10 @@
 targets:
   $default:
+    sources:
+      include:
+        - $package$ # Package metadata.
+        - pubspec.yaml # Package configuration.
+        - lib/** # Dart source files.
     builders:
       widgetbook_generator:use_case_builder:
         generate_for:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -937,10 +937,10 @@ packages:
     dependency: transitive
     description:
       name: go_router
-      sha256: f02fd7d2a4dc512fec615529824fdd217fecb3a3d3de68360293a551f21634b3
+      sha256: "0b1e06223bee260dee31a171fb1153e306907563a0b0225e8c1733211911429a"
       url: "https://pub.dev"
     source: hosted
-    version: "14.8.1"
+    version: "15.1.2"
   go_router_builder:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -69,7 +69,7 @@ melos:
     gen:
       run: dart run build_runner build --delete-conflicting-outputs
       exec:
-        concurrency: 1
+        orderDependents: true
       description: Run generate code.
       packageFilters:
         dirExists: lib
@@ -79,6 +79,7 @@ melos:
       run: dart run build_runner watch --delete-conflicting-outputs
       exec:
         concurrency: 99
+        orderDependents: true
       description: Watch and run generate code.
       packageFilters:
         dirExists: lib
@@ -94,7 +95,7 @@ melos:
     slang:
       run: dart run slang
       exec:
-        concurrency: 1
+        orderDependents: true
       description: Run generate translation code.
       packageFilters:
         dirExists: lib


### PR DESCRIPTION
## 🙌 What's Done
<!-- What has been accomplished in this Pull Request? -->

- Bump GoRouter from v14 to v15
- Edit build.yaml to fix FlutterGen Error in build_runner build
- Add the missing json_annotation dependency
- Use orderDependents instead of concurrency in Melos Script

## ✍️ What's Not Done
<!-- What is not included in this Pull Request? If none, write "None". -->
None

## 📝 Additional Notes
<!-- Additional information for reviewers, such as concerns or implementation notes. -->
- 

## Pre-launch Checklist

- [x] I have reviewed my own code (e.g., updated tests and documentation)
